### PR TITLE
Implemented api for worker registry

### DIFF
--- a/services/entity/worker-registry/api/openapi.yaml
+++ b/services/entity/worker-registry/api/openapi.yaml
@@ -10,15 +10,22 @@ info:
   description: The API for the Worker Registry
 
 paths:
-  /worker:
+  /workers:
     get:
       tags:
         - worker
-      description: Returns all registered workers.
-      operationId: getAllWorkers
+      description: Returns all registered workers or those with a specified status.
+      operationId: getWorkers
+      parameters:
+        - name: status
+          in: query
+          description: Filter workers by their status. Comma-separated values allowed.
+          required: false
+          schema:
+            type: string
       responses:
         '200':
-          description: All registered workers
+          description: Registered workers
           content:
             application/json:
               schema:
@@ -32,6 +39,17 @@ paths:
                   workerStatus: "COMPLETED"
                 - workerId: "06842e74-1121-4700-b6d5-6558c8af6199"
                   workerStatus: "AVAILABLE"
+        '404':
+          description: No workers found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+              example:
+                message: "No workers found"
         '500':
           description: Internal server error
           content:
@@ -43,11 +61,11 @@ paths:
                     type: string
               example:
                 message: "Internal server error"
-
+  /worker:
     post:
       tags:
         - worker
-      description: Registers a new Worker in the Worker Registry. Creates a unique Id and marks newly created worker as "Ready".
+      description: Registers a new Worker in the Worker Registry. Creates a unique Id and marks newly created worker as "AVAILABLE".
       operationId: saveWorker
       responses:
         '201':
@@ -71,48 +89,7 @@ paths:
               example:
                 message: "Internal server error"
 
-  /worker/{status}:
-    get:
-      tags:
-        - worker
-      description: Returns all workers with the specified status
-      operationId: getAllWorkersByStatus
-      parameters:
-        - name: status
-          in: path
-          description: The status of the workers.
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: All registered workers with specified status
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Worker'
-              example:
-                - workerId: "101a8fa4-dce6-4d10-a65a-e88e6edbcdf7"
-                  workerStatus: "AVAILABLE"
-                - workerId: "06842e74-1121-4700-b6d5-6558c8af6198"
-                  workerStatus: "AVAILABLE"
-                - workerId: "06842e74-1121-4700-b6d5-6558c8af6199"
-                  workerStatus: "AVAILABLE"
-        '404':
-          description: Worker was not found
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-              example:
-                message: "Worker not found"
-
-  /worker/{workerId}/status:
+  /worker/status:
     get:
       tags:
         - worker
@@ -120,7 +97,7 @@ paths:
       operationId: getWorkerStatus
       parameters:
         - name: workerId
-          in: path
+          in: query
           description: The identifier of the worker.
           required: true
           schema:
@@ -161,29 +138,18 @@ paths:
       operationId: updateWorkerStatus
       parameters:
         - name: workerId
-          in: path
+          in: query
           description: The identifier of the worker.
           required: true
           schema:
             type: string
             format: uuid
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                workerStatus:
-                  type: string
-                  enum:
-                    - AVAILABLE
-                    - RUNNING
-                    - COMPLETED
-              required:
-                - workerStatus
-            example:
-              workerStatus: "Running"
+        - name: status
+          in: query
+          description: The new status for the worker.
+          required: true
+          schema:
+            type: string
       responses:
         '200':
           description: Worker status updated successfully.

--- a/services/entity/worker-registry/api/openapi.yaml
+++ b/services/entity/worker-registry/api/openapi.yaml
@@ -13,7 +13,7 @@ paths:
   /workers:
     get:
       tags:
-        - worker
+        - workers
       description: Returns all registered workers or those with a specified status.
       operationId: getWorkers
       parameters:
@@ -44,27 +44,13 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
+                $ref: '#/components/schemas/Error'
               example:
-                message: "No workers found"
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-              example:
-                message: "Internal server error"
-  /worker:
+                message: "No workers found."
+
     post:
       tags:
-        - worker
+        - workers
       description: Registers a new Worker in the Worker Registry. Creates a unique Id and marks newly created worker as "AVAILABLE".
       operationId: saveWorker
       responses:
@@ -77,79 +63,66 @@ paths:
               example:
                 workerId: "90bb1e74-22f1-4b91-bf0b-fd17e542cb3e"
                 workerStatus: "AVAILABLE"
-        '500':
-          description: Internal server error
+        '400':
+          description: Worker could not be saved.
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
+                $ref: '#/components/schemas/Error'
               example:
-                message: "Internal server error"
+                message: "Worker could not be saved."      
 
-  /worker/status:
+  /workers/{workerId}:
     get:
       tags:
-        - worker
-      description: Retrieves the status of the specified worker.
-      operationId: getWorkerStatus
+        - workers
+      description: Retrieves a worker by their ID.
+      operationId: getWorkerById
       parameters:
         - name: workerId
-          in: query
-          description: The identifier of the worker.
+          in: path
           required: true
           schema:
             type: string
             format: uuid
       responses:
         '200':
-          description: Worker status retrieved successfully.
+          description: Worker retrieved successfully.
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  workerStatus:
-                    type: string
-                    enum:
-                      - AVAILABLE
-                      - RUNNING
-                      - COMPLETED
-              example:
-                workerStatus: "AVAILABLE"
+                $ref: '#/components/schemas/Worker'
         '404':
-          description: Worker was not found
+          description: Worker not found
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
+                $ref: '#/components/schemas/Error'
               example:
-                message: "Worker not found"
-
+                message: "Worker not found."
+                
     patch:
       tags:
-        - worker
-      description: Updates the status of a specific worker to "AVAILABLE", "RUNNING" or "COMPLETED".
+        - workers
+      description: Updates a specific worker. Valid workerStatus values are "AVAILABLE", "RUNNING" or "COMPLETED".
       operationId: updateWorkerStatus
       parameters:
         - name: workerId
-          in: query
-          description: The identifier of the worker.
+          in: path
           required: true
           schema:
             type: string
             format: uuid
-        - name: status
-          in: query
-          description: The new status for the worker.
-          required: true
-          schema:
-            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                workerStatus:
+                  type: string
+                  enum: [AVAILABLE, RUNNING, COMPLETED]
       responses:
         '200':
           description: Worker status updated successfully.
@@ -157,31 +130,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Worker'
-              example:
-                workerId: "101a8fa4-dce6-4d10-a65a-e88e6edbcdf7"
-                workerStatus: "RUNNING"
-        '404':
-          description: Worker was not found
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-              example:
-                message: "Worker not found"
         '400':
           description: Invalid worker status provided.
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
+                $ref: '#/components/schemas/Error'
               example:
-                message: "Invalid value for workerStatus. Allowed values are 'AVAILABLE', 'RUNNING' or 'COMPLETED'."
+                message: "Invalid Requestbody."
+        '404':
+          description: Worker not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                message: "Worker not found."
 
 components:
   schemas:
@@ -198,6 +162,12 @@ components:
             - AVAILABLE
             - RUNNING
             - COMPLETED
-      example:
-        workerId: "101a8fa4-dce6-4d10-a65a-e88e6edbcdf7"
-        workerStatus: "RUNNING"
+      required:
+        - workerId
+        - workerStatus
+
+    Error:
+      type: object
+      properties:
+        message:
+          type: string

--- a/services/entity/worker-registry/api/openapi.yaml
+++ b/services/entity/worker-registry/api/openapi.yaml
@@ -27,11 +27,11 @@ paths:
                   $ref: '#/components/schemas/Worker'
               example:
                 - workerId: "101a8fa4-dce6-4d10-a65a-e88e6edbcdf7"
-                  workerStatus: "Running"
+                  workerStatus: "RUNNING"
                 - workerId: "06842e74-1121-4700-b6d5-6558c8af6198"
-                  workerStatus: "Stopped"
+                  workerStatus: "COMPLETED"
                 - workerId: "06842e74-1121-4700-b6d5-6558c8af6199"
-                  workerStatus: "Ready"
+                  workerStatus: "AVAILABLE"
         '500':
           description: Internal server error
           content:
@@ -58,7 +58,7 @@ paths:
                 $ref: '#/components/schemas/Worker'
               example:
                 workerId: "90bb1e74-22f1-4b91-bf0b-fd17e542cb3e"
-                workerStatus: "Ready"
+                workerStatus: "AVAILABLE"
         '500':
           description: Internal server error
           content:
@@ -95,11 +95,11 @@ paths:
                   $ref: '#/components/schemas/Worker'
               example:
                 - workerId: "101a8fa4-dce6-4d10-a65a-e88e6edbcdf7"
-                  workerStatus: "Ready"
+                  workerStatus: "AVAILABLE"
                 - workerId: "06842e74-1121-4700-b6d5-6558c8af6198"
-                  workerStatus: "Ready"
+                  workerStatus: "AVAILABLE"
                 - workerId: "06842e74-1121-4700-b6d5-6558c8af6199"
-                  workerStatus: "Ready"
+                  workerStatus: "AVAILABLE"
         '404':
           description: Worker was not found
           content:
@@ -137,11 +137,11 @@ paths:
                   workerStatus:
                     type: string
                     enum:
-                      - Ready
-                      - Running
-                      - Stopped
+                      - AVAILABLE
+                      - RUNNING
+                      - COMPLETED
               example:
-                workerStatus: "Ready"
+                workerStatus: "AVAILABLE"
         '404':
           description: Worker was not found
           content:
@@ -157,7 +157,7 @@ paths:
     patch:
       tags:
         - worker
-      description: Updates the status of a specific worker to "Ready", "Running" or "Stopped".
+      description: Updates the status of a specific worker to "AVAILABLE", "RUNNING" or "COMPLETED".
       operationId: updateWorkerStatus
       parameters:
         - name: workerId
@@ -177,9 +177,9 @@ paths:
                 workerStatus:
                   type: string
                   enum:
-                    - Ready
-                    - Running
-                    - Stopped
+                    - AVAILABLE
+                    - RUNNING
+                    - COMPLETED
               required:
                 - workerStatus
             example:
@@ -193,7 +193,7 @@ paths:
                 $ref: '#/components/schemas/Worker'
               example:
                 workerId: "101a8fa4-dce6-4d10-a65a-e88e6edbcdf7"
-                workerStatus: "Running"
+                workerStatus: "RUNNING"
         '404':
           description: Worker was not found
           content:
@@ -215,7 +215,7 @@ paths:
                   message:
                     type: string
               example:
-                message: "Invalid value for workerStatus. Allowed values are 'Ready', 'Running' or 'Stopped'."
+                message: "Invalid value for workerStatus. Allowed values are 'AVAILABLE', 'RUNNING' or 'COMPLETED'."
 
 components:
   schemas:
@@ -229,9 +229,9 @@ components:
         workerStatus:
           type: string
           enum:
-            - Ready
-            - Running
-            - Stopped
+            - AVAILABLE
+            - RUNNING
+            - COMPLETED
       example:
         workerId: "101a8fa4-dce6-4d10-a65a-e88e6edbcdf7"
-        workerStatus: "Running"
+        workerStatus: "RUNNING"

--- a/services/entity/worker-registry/api/openapi.yaml
+++ b/services/entity/worker-registry/api/openapi.yaml
@@ -1,0 +1,212 @@
+openapi: 3.0.0
+
+servers:
+  - url: http://localhost:8080
+    description: Local development server
+
+info:
+  version: 1.0.0
+  title: Worker Registry API
+  description: The API for the Worker Registry
+paths:
+  /worker:
+    get:
+      tags:
+        - worker
+      description: Returns all registered workers.
+      operationId: getAllWorkers
+      responses:
+        '200':
+          description: All registered workers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Worker'
+              example:
+                - workerId: "101a8fa4-dce6-4d10-a65a-e88e6edbcdf7"
+                  workerName: "Worker 1"
+                  workerStatus: "Running"
+                - workerId: "06842e74-1121-4700-b6d5-6558c8af6198"
+                  workerName: "Worker 2"
+                  workerStatus: "Stopped"
+        '500':
+            description: "Internal server error"
+    post:
+      tags:
+        - worker
+      description: Saves a new Worker in the Worker Registry.
+      operationId: saveWorker
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewWorker'
+            example:
+              workerName: "Worker 1"
+              workerStatus: "Running"
+      responses:
+        '201':
+          description: Worker successfully saved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Worker'
+              example:
+                workerId: "90bb1e74-22f1-4b91-bf0b-fd17e542cb3e"
+                workerName: "Worker 1"
+                workerStatus: "Running"
+        '400':
+          description: Worker could not be saved.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Worker does already exist or cannot be saved."
+
+  /worker/{workerId}:
+    get:
+      tags:
+        - worker
+      description: Returns the worker with the specified workerId
+      operationId: getWorkerById
+      parameters:
+        - name: workerId
+          in: path
+          description: The identifier of the worker.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: A single worker
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Worker'
+              example:
+                workerId: "101a8fa4-dce6-4d10-a65a-e88e6edbcdf7"
+                workerName: "Worker 1"
+                workerStatus: "Running"
+        '404':
+          description: Worker was not found.
+
+  /worker/{workerId}/status:
+    get:
+      tags:
+        - worker
+      description: Retrieves the status of the specified worker.
+      operationId: getWorkerStatus
+      parameters:
+        - name: workerId
+          in: path
+          description: The identifier of the worker.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Worker status retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  workerStatus:
+                    type: string
+                    enum:
+                      - Running
+                      - Stopped
+              example:
+                workerStatus: "Running"
+        '404':
+          description: Worker was not found.
+
+    patch:
+      tags:
+        - worker
+      description: Updates the status of a specific worker to "Running" or "Stopped".
+      operationId: updateWorkerStatus
+      parameters:
+        - name: workerId
+          in: path
+          description: The identifier of the worker.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                workerStatus:
+                  type: string
+                  enum:
+                    - Running
+                    - Stopped
+              required:
+                - workerStatus
+            example:
+              workerStatus: "Running"
+      responses:
+        '200':
+          description: Worker status updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Worker'
+              example:
+                workerId: "101a8fa4-dce6-4d10-a65a-e88e6edbcdf7"
+                workerName: "Worker 1"
+                workerStatus: "Running"
+        '404':
+          description: Worker was not found.
+        '400':
+          description: Invalid worker status provided.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Invalid value for workerStatus. Allowed values are 'Running' or 'Stopped'."
+
+components:
+  schemas:
+    Worker:
+      type: object
+      description: Worker details
+      properties:
+        workerId:
+          type: string
+          format: uuid
+        workerName:
+          type: string
+        workerStatus:
+          type: string
+      example:
+        workerId: "101a8fa4-dce6-4d10-a65a-e88e6edbcdf7"
+        workerName: "Worker 1"
+        workerStatus: "Running"
+    NewWorker:
+      type: object
+      description: Payload to create a new worker
+      required:
+        - workerName
+        - workerStatus
+      properties:
+        workerName:
+          type: string
+        workerStatus:
+          type: string

--- a/services/entity/worker-registry/api/openapi.yaml
+++ b/services/entity/worker-registry/api/openapi.yaml
@@ -8,6 +8,7 @@ info:
   version: 1.0.0
   title: Worker Registry API
   description: The API for the Worker Registry
+
 paths:
   /worker:
     get:
@@ -26,27 +27,28 @@ paths:
                   $ref: '#/components/schemas/Worker'
               example:
                 - workerId: "101a8fa4-dce6-4d10-a65a-e88e6edbcdf7"
-                  workerName: "Worker 1"
                   workerStatus: "Running"
                 - workerId: "06842e74-1121-4700-b6d5-6558c8af6198"
-                  workerName: "Worker 2"
                   workerStatus: "Stopped"
+                - workerId: "06842e74-1121-4700-b6d5-6558c8af6199"
+                  workerStatus: "Ready"
         '500':
-            description: "Internal server error"
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+              example:
+                message: "Internal server error"
+
     post:
       tags:
         - worker
-      description: Saves a new Worker in the Worker Registry.
+      description: Registers a new Worker in the Worker Registry. Creates a unique Id and marks newly created worker as "Ready".
       operationId: saveWorker
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/NewWorker'
-            example:
-              workerName: "Worker 1"
-              workerStatus: "Running"
       responses:
         '201':
           description: Worker successfully saved.
@@ -56,10 +58,9 @@ paths:
                 $ref: '#/components/schemas/Worker'
               example:
                 workerId: "90bb1e74-22f1-4b91-bf0b-fd17e542cb3e"
-                workerName: "Worker 1"
-                workerStatus: "Running"
-        '400':
-          description: Worker could not be saved.
+                workerStatus: "Ready"
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -67,35 +68,49 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: "Worker does already exist or cannot be saved."
+              example:
+                message: "Internal server error"
 
-  /worker/{workerId}:
+  /worker/{status}:
     get:
       tags:
         - worker
-      description: Returns the worker with the specified workerId
-      operationId: getWorkerById
+      description: Returns all workers with the specified status
+      operationId: getAllWorkersByStatus
       parameters:
-        - name: workerId
+        - name: status
           in: path
-          description: The identifier of the worker.
+          description: The status of the workers.
           required: true
           schema:
             type: string
-            format: uuid
       responses:
         '200':
-          description: A single worker
+          description: All registered workers with specified status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Worker'
+                type: array
+                items:
+                  $ref: '#/components/schemas/Worker'
               example:
-                workerId: "101a8fa4-dce6-4d10-a65a-e88e6edbcdf7"
-                workerName: "Worker 1"
-                workerStatus: "Running"
+                - workerId: "101a8fa4-dce6-4d10-a65a-e88e6edbcdf7"
+                  workerStatus: "Ready"
+                - workerId: "06842e74-1121-4700-b6d5-6558c8af6198"
+                  workerStatus: "Ready"
+                - workerId: "06842e74-1121-4700-b6d5-6558c8af6199"
+                  workerStatus: "Ready"
         '404':
-          description: Worker was not found.
+          description: Worker was not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+              example:
+                message: "Worker not found"
 
   /worker/{workerId}/status:
     get:
@@ -122,17 +137,27 @@ paths:
                   workerStatus:
                     type: string
                     enum:
+                      - Ready
                       - Running
                       - Stopped
               example:
-                workerStatus: "Running"
+                workerStatus: "Ready"
         '404':
-          description: Worker was not found.
+          description: Worker was not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+              example:
+                message: "Worker not found"
 
     patch:
       tags:
         - worker
-      description: Updates the status of a specific worker to "Running" or "Stopped".
+      description: Updates the status of a specific worker to "Ready", "Running" or "Stopped".
       operationId: updateWorkerStatus
       parameters:
         - name: workerId
@@ -152,6 +177,7 @@ paths:
                 workerStatus:
                   type: string
                   enum:
+                    - Ready
                     - Running
                     - Stopped
               required:
@@ -167,10 +193,18 @@ paths:
                 $ref: '#/components/schemas/Worker'
               example:
                 workerId: "101a8fa4-dce6-4d10-a65a-e88e6edbcdf7"
-                workerName: "Worker 1"
                 workerStatus: "Running"
         '404':
-          description: Worker was not found.
+          description: Worker was not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+              example:
+                message: "Worker not found"
         '400':
           description: Invalid worker status provided.
           content:
@@ -180,7 +214,8 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: "Invalid value for workerStatus. Allowed values are 'Running' or 'Stopped'."
+              example:
+                message: "Invalid value for workerStatus. Allowed values are 'Ready', 'Running' or 'Stopped'."
 
 components:
   schemas:
@@ -191,22 +226,12 @@ components:
         workerId:
           type: string
           format: uuid
-        workerName:
-          type: string
         workerStatus:
           type: string
+          enum:
+            - Ready
+            - Running
+            - Stopped
       example:
         workerId: "101a8fa4-dce6-4d10-a65a-e88e6edbcdf7"
-        workerName: "Worker 1"
         workerStatus: "Running"
-    NewWorker:
-      type: object
-      description: Payload to create a new worker
-      required:
-        - workerName
-        - workerStatus
-      properties:
-        workerName:
-          type: string
-        workerStatus:
-          type: string


### PR DESCRIPTION
### Addition of OpenAPI Specification for Worker Registry API:

* Created a new OpenAPI specification for the Worker Registry API

#### Defined API Endpoints:
* **`/workers`**:
  - [`GET`](diffhunk://#diff-c46a835bd7e6c611147cd200bf28b97878a8c269cc995e0afa12eaf8366e8534R1-R173): Retrieves all registered workers or filters them by status. Returns a list of workers or a 404 error if none are found.
  - [`POST`](diffhunk://#diff-c46a835bd7e6c611147cd200bf28b97878a8c269cc995e0afa12eaf8366e8534R1-R173): Registers a new worker with a status of "AVAILABLE". Returns the created worker or a 400 error if the operation fails.
* **`/workers/{workerId}`**:
  - [`GET`](diffhunk://#diff-c46a835bd7e6c611147cd200bf28b97878a8c269cc995e0afa12eaf8366e8534R1-R173): Fetches a worker by their unique ID. Returns the worker or a 404 error if not found.
  - `PATCH`: Updates a specific worker. Accepts "AVAILABLE", "RUNNING", or "COMPLETED" as valid workerStatus values. Returns the updated worker or errors for invalid input or if the worker is not found. (F8