### PR TITLE
Added a script to add and remove images to/from the ACR

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,83 @@
 
 Cloud-native Microservices mit Go - SoSe 2025
 
+## Azure Container Registry (ACR) Management Script
+
+A Bash script for managing Docker images in Azure Container Registry with easy push/delete operations.
+
+## 🛠️ Prerequisites
+1. **Azure CLI** installed and configured:
+   ```bash
+   az login
+   ```
+2. **Docker** installed and Docker Daemon running
+3. **Permissions** to access the ACR (Contributor or Owner Role). To do so you have to be added to the azure resource group by authority.
+
+## 📥 Execution
+
+1. Make it executable:
+   ```bash
+   chmod +x acr_manager.sh
+   ``` 
+
+2. Execute from **project root**:
+   ```bash
+    ./acr_manager.sh
+   ```
+
+## 🚀 Usage
+```
+1 - Login to ACR          # Authenticates with your registry
+2 - Push image            # Tags and uploads a local image
+3 - Delete image          # Removes tags or purges entire repository
+4 - Exit
+```
+
+## 🛠️ How It Works
+### 🔐 Authentication
+- Uses `az acr login` to authenticate Docker with your ACR
+- Required only once per session
+
+### 📤 Pushing Images
+- Enter local image name (e.g., `cmg-ss2025-job-service`)
+- Target tag (e.g., `v1`)
+- Actions:
+   ```bash
+   docker tag my-app:latest cmgss2025.azurecr.io/my-app:v1
+   docker push cmgss2025.azurecr.io/my-app:v1
+   ``` 
+
+### 🗑️ Deleting Images
+1. Safe Workflow:
+    - First lists all existing tags
+    - Chose between:
+        - Single tag deletion (`untag`)
+        - Full purge (`--purge`) with confirmation
+
+## 📋 Examples
+### Push an Image:
+```bash
+$ ./acr_manager.sh
+Choose action (1-4): 2
+Local image name: cmg-ss2025-job-service
+Tag: v1
+✅ Successfully pushed: cmgss2025.azurecr.io/my-app:v1
+```
+### Delete an Image:
+```bash
+$ ./acr_manager.sh
+Choose action (1-4): 3
+Image name: my-app
+Existing tags: latest, v1, v2
+Tag to delete: v1
+✅ Deleted tag: my-app:v1
+```
+
 # List of approved packages
 
 | Package                              | Description                                  |
 |--------------------------------------|----------------------------------------------|
 | `github.com/gorilla/mux`             | HTTP request router and dispatcher           |
 | `github.com/google/uuid`             | UUID generation (e.g., for user identifiers) |
+
+

--- a/acr_manager.sh
+++ b/acr_manager.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Configuration
+ACR_NAME="cmgss2025"                  # Your ACR name (without .azurecr.io)
+RESOURCE_GROUP="cmg-ss2025"           # Azure Resource Group
+AZURE_CMD="az"                        # Azure CLI command
+DOCKER_CMD="docker"                   # Docker command
+FULL_ACR_NAME="$ACR_NAME.azurecr.io"  # Full registry name
+
+# Functions
+login_to_acr() {
+    echo "### Login to Azure Container Registry ###"
+    $AZURE_CMD acr login --name $ACR_NAME
+    echo "✅ Logged in to $FULL_ACR_NAME"
+}
+
+push_image() {
+    echo "### Push Image to ACR ###"
+    read -p "Local image name (e.g., cmg-ss2025-job-service): " LOCAL_IMAGE
+    read -p "Tag (e.g., v1): " TAG
+
+    # Remove existing tag if it exists
+    $DOCKER_CMD rmi "$FULL_ACR_NAME/$LOCAL_IMAGE:$TAG" 2>/dev/null || true
+
+    # Tag and push
+    $DOCKER_CMD tag "$LOCAL_IMAGE" "$FULL_ACR_NAME/$LOCAL_IMAGE:$TAG"
+    $DOCKER_CMD push "$FULL_ACR_NAME/$LOCAL_IMAGE:$TAG"
+
+    echo "✅ Successfully pushed: $FULL_ACR_NAME/$LOCAL_IMAGE:$TAG"
+}
+
+delete_image() {
+    echo "### Delete Image from ACR ###"
+    read -p "Image name in ACR (without tag, e.g., cmg-ss2025-job-service): " IMAGE_NAME
+    
+    # Show existing tags first
+    echo "🔍 Existing tags for $IMAGE_NAME:"
+    $AZURE_CMD acr repository show-tags --name $ACR_NAME --repository "$IMAGE_NAME" --output tsv
+    
+    read -p "Tag to delete (e.g., v1) or '--purge' to delete ALL tags: " TAG
+
+    if [[ "$TAG" == "--purge" ]]; then
+        echo "⚠️ WARNING: This will delete ALL tags and manifests for $IMAGE_NAME!"
+        read -p "Are you sure? (y/n): " CONFIRM
+        if [[ "$CONFIRM" == "y" ]]; then
+            $AZURE_CMD acr repository delete \
+                --name $ACR_NAME \
+                --repository "$IMAGE_NAME" \
+                --yes
+            echo "✅ Deleted ALL tags for $IMAGE_NAME"
+        else
+            echo "🚫 Deletion cancelled"
+        fi
+    else
+        echo "ℹ️ This will only delete the specific tag '$TAG'"
+        $AZURE_CMD acr repository untag \
+            --name $ACR_NAME \
+            --image "$IMAGE_NAME:$TAG"
+        echo "✅ Deleted tag: $IMAGE_NAME:$TAG"
+    fi
+}
+
+# Menu
+while true; do
+    echo ""
+    echo "1 - Login to ACR"
+    echo "2 - Push image"
+    echo "3 - Delete image"
+    echo "4 - Exit"
+    read -p "Choose action (1-4): " CHOICE
+
+    case $CHOICE in
+        1) login_to_acr ;;
+        2) push_image ;;
+        3) delete_image ;;
+        4) break ;;
+        *) echo "❌ Invalid input" ;;
+    esac
+done


### PR DESCRIPTION
I have created an Azure Container Registry (ACR) manually in the resource group. 
Additionally I created a script which can push local images to the ACR.
Examples already exist and can be found by navigating through the Azure Container Registry:
`Container Registry -> Services -> Repositories`
 
Furthermore an image from the ACR can easily be deleted.

@seboste we talked about me creating this script to simplify pushing and removing images. The usage of the script is intuitive but it still takes some minor steps to manage images. Is this approach okay?