### PR TITLE
Job service - empty creationzone field during job creation

### DIFF
--- a/services/job/adapters/handler-http/handler.go
+++ b/services/job/adapters/handler-http/handler.go
@@ -58,7 +58,7 @@ func (h *Handler) GetJobs(w http.ResponseWriter, r *http.Request) {
 
 	jobs, err := h.service.GetJobs(r.Context(), statuses)
 	if err != nil {
-		http.Error(w, ports.HTTPErr500, http.StatusInternalServerError)
+		http.Error(w, HTTPErr500, http.StatusInternalServerError)
 		return
 	}
 
@@ -75,7 +75,7 @@ func (h *Handler) GetJobs(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) CreateJob(w http.ResponseWriter, r *http.Request) {
 	var job ports.JobCreate
 	if err := json.NewDecoder(r.Body).Decode(&job); err != nil {
-		http.Error(w, ports.HTTPErr400InvalidInputData, http.StatusBadRequest)
+		http.Error(w, HTTPErr400InvalidInputData, http.StatusBadRequest)
 		return
 	}
 
@@ -126,7 +126,7 @@ func (h *Handler) UpdateJobScheduler(w http.ResponseWriter, r *http.Request) {
 	var updateData ports.SchedulerUpdateData
 	err := json.NewDecoder(r.Body).Decode(&updateData)
 	if err != nil {
-		http.Error(w, ports.HTTPErr400InvalidInputData, http.StatusBadRequest)
+		http.Error(w, HTTPErr400InvalidInputData, http.StatusBadRequest)
 		return
 	}
 
@@ -147,7 +147,7 @@ func (h *Handler) UpdateJobWorkerDaemon(w http.ResponseWriter, r *http.Request) 
 	var updateData ports.WorkerDaemonUpdateData
 	err := json.NewDecoder(r.Body).Decode(&updateData)
 	if err != nil {
-		http.Error(w, ports.HTTPErr400InvalidInputData, http.StatusBadRequest)
+		http.Error(w, HTTPErr400InvalidInputData, http.StatusBadRequest)
 		return
 	}
 
@@ -165,19 +165,19 @@ func CheckAndSetErr(w http.ResponseWriter, err error) bool {
 	if err != nil {
 		switch err {
 		case ports.ErrNotExistingID:
-			http.Error(w, ports.HTTPErr400MissId, http.StatusBadRequest)
+			http.Error(w, HTTPErr400MissId, http.StatusBadRequest)
 		case ports.ErrInvalidIDFormat:
-			http.Error(w, ports.HTTPErr400InvalidId, http.StatusBadRequest)
+			http.Error(w, HTTPErr400InvalidId, http.StatusBadRequest)
 		case ports.ErrJobNotFound:
-			http.Error(w, ports.HTTPErr400JobNotFound, http.StatusNotFound)
-		case ports.ErrNotExistingJobName, ports.ErrNotExistingZone, ports.ErrNotExistingImageName:
-			http.Error(w, ports.HTTPErr400FieldEmpty, http.StatusBadRequest)
+			http.Error(w, HTTPErr400JobNotFound, http.StatusNotFound)
+		case ports.ErrNotExistingJobName, ports.ErrNotExistingImageName:
+			http.Error(w, HTTPErr400FieldEmpty, http.StatusBadRequest)
 		case ports.ErrImageVersionIsInvalid, ports.ErrParamKeyValueEmpty:
-			http.Error(w, ports.HTTPErr400InvalidInputData, http.StatusBadRequest)
+			http.Error(w, HTTPErr400InvalidInputData, http.StatusBadRequest)
 		case ports.ErrNotExistingStatus:
-			http.Error(w, ports.HTTPErr400StatusEmpty, http.StatusBadRequest)
+			http.Error(w, HTTPErr400StatusEmpty, http.StatusBadRequest)
 		default:
-			http.Error(w, ports.HTTPErr500, http.StatusInternalServerError)
+			http.Error(w, HTTPErr500, http.StatusInternalServerError)
 		}
 		return true
 	}

--- a/services/job/adapters/handler-http/handler_error.go
+++ b/services/job/adapters/handler-http/handler_error.go
@@ -1,0 +1,11 @@
+package handler_http
+
+var (
+	HTTPErr400MissId           = `{"error": "Bad Request","message": "The job ID must be provided"}`
+	HTTPErr400InvalidId        = `{"error": "Bad Request","message": "The job ID format is invalid. Expected a UUID format."}`
+	HTTPErr400JobNotFound      = `{"error": "Not Found","message": "A job with the specified ID does not exist. Please verify the ID."}`
+	HTTPErr400FieldEmpty       = `{"error": "Bad Request","message": "jobname and imagename must not be empty"}`
+	HTTPErr400StatusEmpty      = `{"error": "Bad Request","message": "job status must not be empty"}`
+	HTTPErr400InvalidInputData = `{"error": "Bad Request","message": "Invalid input data"}`
+	HTTPErr500                 = `{"error": "Internal Server Error","message": "The server encountered an unexpected condition"}`
+)

--- a/services/job/core/job.go
+++ b/services/job/core/job.go
@@ -64,9 +64,6 @@ func (s *JobService) CreateJob(ctx context.Context, jobCreate ports.JobCreate) (
 	if strings.TrimSpace(jobCreate.JobName) == "" {
 		return ports.Job{}, ports.ErrNotExistingJobName
 	}
-	if strings.TrimSpace(jobCreate.CreationZone) == "" {
-		return ports.Job{}, ports.ErrNotExistingZone
-	}
 	if strings.TrimSpace(jobCreate.Image.Name) == "" {
 		return ports.Job{}, ports.ErrNotExistingImageName
 	}

--- a/services/job/ports/error.go
+++ b/services/job/ports/error.go
@@ -8,21 +8,10 @@ var (
 	ErrJobNotFound           = errors.New("job not found")
 	ErrNotExistingJobName    = errors.New("job name must be provided")
 	ErrNotExistingStatus     = errors.New("job status must be provided")
-	ErrNotExistingZone       = errors.New("creation zone must be provided")
 	ErrNotExistingImageName  = errors.New("image name must be provided")
 	ErrNotExistingWorkerID   = errors.New("worker ID must be provided")
 	ErrImageVersionIsInvalid = errors.New("image version format is invalid")
 	ErrParamKeyValueEmpty    = errors.New("parameters cannot have empty keys or values")
 	ErrErrorMessageEmpty     = errors.New("error message must be provided for failed jobs")
 	ErrCarbonIsNegative      = errors.New("carbon intensity must be non-negative")
-)
-
-var (
-	HTTPErr400MissId           = `{"error": "Bad Request","message": "The job ID must be provided"}`
-	HTTPErr400InvalidId        = `{"error": "Bad Request","message": "The job ID format is invalid. Expected a UUID format."}`
-	HTTPErr400JobNotFound      = `{"error": "Not Found","message": "A job with the specified ID does not exist. Please verify the ID."}`
-	HTTPErr400FieldEmpty       = `{"error": "Bad Request","message": "jobname, creatzone and imagename must not be empty"}`
-	HTTPErr400StatusEmpty      = `{"error": "Bad Request","message": "job status must not be empty"}`
-	HTTPErr400InvalidInputData = `{"error": "Bad Request","message": "Invalid input data"}`
-	HTTPErr500                 = `{"error": "Internal Server Error","message": "The server encountered an unexpected condition"}`
 )


### PR DESCRIPTION
as agreed in class, errors were positioned logically and CreationZone was allowed as an empty field (for the creation of a job)