### PR TITLE
Refined make process

### DIFF
--- a/services/carbon-intensity-provider/Makefile
+++ b/services/carbon-intensity-provider/Makefile
@@ -1,10 +1,18 @@
 BINARY_NAME=carbon-intensity-provider-binary
 DOCKER_IMAGE=carbon-intensity-provider
 
-.PHONY: all build test containerize
+.PHONY: all build test containerize clean integrationcheck deployment
 
-integrationcheck: build test 
-deployment: build test containerize
+integrationcheck:
+	@$(MAKE) build && \
+	$(MAKE) test ; \
+	$(MAKE) clean
+	
+deployment:
+	@$(MAKE) build && \
+	$(MAKE) test && \
+	$(MAKE) containerize ; \
+	$(MAKE) clean
 
 build:
 	go build -o $(BINARY_NAME) .
@@ -14,3 +22,6 @@ test:
 
 containerize:
 	docker build -t $(DOCKER_IMAGE) .
+
+clean:
+	rm -f $(BINARY_NAME)

--- a/services/cli/Makefile
+++ b/services/cli/Makefile
@@ -1,12 +1,18 @@
 BINARY_NAME=cli-binary
 
-.PHONY: all build test
+.PHONY: all build test clean integrationcheck
 
-integrationcheck: build test 
+integrationcheck:
+	@$(MAKE) build && \
+	$(MAKE) test ; \
+	$(MAKE) clean
 
 build:
 	go build -o $(BINARY_NAME) .
 
 test:
 	go test ./...
+
+clean:
+	rm -f $(BINARY_NAME)
 

--- a/services/consumer-gateway/Makefile
+++ b/services/consumer-gateway/Makefile
@@ -1,10 +1,18 @@
 BINARY_NAME=consumer-gateway-binary
 DOCKER_IMAGE=consumer-gateway
 
-.PHONY: all build test containerize
+.PHONY: all build test containerize clean integrationcheck deployment
 
-integrationcheck: build test 
-deployment: build test containerize
+integrationcheck:
+	@$(MAKE) build && \
+	$(MAKE) test ; \
+	$(MAKE) clean
+	
+deployment:
+	@$(MAKE) build && \
+	$(MAKE) test && \
+	$(MAKE) containerize ; \
+	$(MAKE) clean
 
 build:
 	go build -o $(BINARY_NAME) .
@@ -14,3 +22,6 @@ test:
 
 containerize:
 	docker build -t $(DOCKER_IMAGE) .
+
+clean:
+	rm -f $(BINARY_NAME)

--- a/services/job-scheduler/Makefile
+++ b/services/job-scheduler/Makefile
@@ -1,10 +1,18 @@
 BINARY_NAME=job-scheduler-binary
 DOCKER_IMAGE=job-scheduler
 
-.PHONY: all build containerize test run docker-up docker-down  
+.PHONY: all build containerize test run docker-up docker-down clean integrationcheck deployment
 
-integrationcheck: build test 
-deployment: build test containerize
+integrationcheck:
+	@$(MAKE) build && \
+	$(MAKE) test ; \
+	$(MAKE) clean
+	
+deployment:
+	@$(MAKE) build && \
+	$(MAKE) test && \
+	$(MAKE) containerize ; \
+	$(MAKE) clean
 
 build:
 	go build -o $(BINARY_NAME) .
@@ -23,6 +31,9 @@ docker-up:
 
 docker-down:
 	docker compose down
+
+clean:
+	rm -f $(BINARY_NAME)
 
 
 

--- a/services/job/Makefile
+++ b/services/job/Makefile
@@ -1,10 +1,18 @@
 BINARY_NAME=job-binary
 DOCKER_IMAGE=job
 
-.PHONY: all build test containerize
+.PHONY: all build test containerize clean integrationcheck deployment
 
-integrationcheck: build test 
-deployment: build test containerize
+integrationcheck:
+	@$(MAKE) build && \
+	$(MAKE) test ; \
+	$(MAKE) clean
+	
+deployment:
+	@$(MAKE) build && \
+	$(MAKE) test && \
+	$(MAKE) containerize ; \
+	$(MAKE) clean
 
 build:
 	go build -o $(BINARY_NAME) .
@@ -14,4 +22,7 @@ test:
 
 containerize:
 	docker build -t $(DOCKER_IMAGE) .
+
+clean:
+	rm -f $(BINARY_NAME)
 

--- a/services/user-management/Makefile
+++ b/services/user-management/Makefile
@@ -1,10 +1,18 @@
 BINARY_NAME=user-management-binary
 DOCKER_IMAGE=user-management
 
-.PHONY: all build test containerize run fmt docker-down clean
+.PHONY: all build test containerize run fmt docker-down clean integrationcheck deployment
 
-integrationcheck: build test 
-deployment: build test containerize
+integrationcheck:
+	@$(MAKE) build && \
+	$(MAKE) test ; \
+	$(MAKE) clean
+	
+deployment:
+	@$(MAKE) build && \
+	$(MAKE) test && \
+	$(MAKE) containerize ; \
+	$(MAKE) clean
 
 build:
 	go build -o $(BINARY_NAME) .
@@ -25,4 +33,4 @@ docker-down:
 	docker compose down
 
 clean:
-	rm -f user-management
+	rm -f $(BINARY_NAME)

--- a/services/worker-deamon/Makefile
+++ b/services/worker-deamon/Makefile
@@ -1,14 +1,19 @@
 BINARY_NAME=worker-deamon-binary
 DOCKER_IMAGE=worker-deamon
 
-.PHONY: all build test 
+.PHONY: all build test integrationcheck clean
 
-integrationcheck: build test 
+integrationcheck:
+	@$(MAKE) build && \
+	$(MAKE) test ; \
+	$(MAKE) clean
 
 build:
-	go build -o $(BINARY_NAME) .
+	go build -o $(BINARY_NAME) ./cmd/worker-deamon
 
 test:
 	go test ./...
 
+clean:
+	rm -f $(BINARY_NAME)
 

--- a/services/worker-gateway/Makefile
+++ b/services/worker-gateway/Makefile
@@ -1,10 +1,18 @@
 BINARY_NAME=worker-gateway-binary
 DOCKER_IMAGE=worker-gateway
 
-.PHONY: all build test containerize
+.PHONY: all build test containerize clean integrationcheck deployment
 
-integrationcheck: build test 
-deployment: build test containerize
+integrationcheck:
+	@$(MAKE) build && \
+	$(MAKE) test ; \
+	$(MAKE) clean
+	
+deployment:
+	@$(MAKE) build && \
+	$(MAKE) test && \
+	$(MAKE) containerize ; \
+	$(MAKE) clean
 
 build:
 	go build -o $(BINARY_NAME) .
@@ -15,3 +23,5 @@ test:
 containerize:
 	docker build -t $(DOCKER_IMAGE) .
 
+clean:
+	rm -f $(BINARY_NAME)

--- a/services/worker-registry/Makefile
+++ b/services/worker-registry/Makefile
@@ -1,10 +1,18 @@
 BINARY_NAME=worker-registry-binary
 DOCKER_IMAGE=worker-registry
 
-.PHONY: all build test containerize run fmt docker-up docker-down
+.PHONY: all build test containerize run fmt docker-up docker-down clean integrationcheck deployment
 
-integrationcheck: build test 
-deployment: build test containerize
+integrationcheck:
+	@$(MAKE) build && \
+	$(MAKE) test ; \
+	$(MAKE) clean
+
+deployment:
+	@$(MAKE) build && \
+	$(MAKE) test && \
+	$(MAKE) containerize ; \
+	$(MAKE) clean
 
 build:
 	go build -o $(BINARY_NAME) .
@@ -23,3 +31,6 @@ docker-up:
 
 docker-down:
 	docker compose down
+
+clean:
+	rm -f $(BINARY_NAME)


### PR DESCRIPTION
1. Added clean targets to remove binarys which arent needed.
2. The image construction will not start until the construction and testing have been successful

tip: If you ever have problems with write permissions, it can help to clone the repo again. I had problems with recopying the binaries due to a lack of rights