### PR TITLE
make gateway compatible with user management

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -80,12 +80,14 @@ services:
       dockerfile: Dockerfile
     container_name: consumer-gateway
     environment:
-      - JOB_SERVICE=http://job-service:8080
-      - USER_MANAGEMENT=http://user-management:8080
-      - CARBON_INTENSITY_PROVIDER=http://carbon-intensity-provider:8080
+      - JOB_SERVICE=http://job-service
+      - USER_MANAGEMENT_SERVICE=http://user-management
+      - CARBON_INTENSITY_PROVIDER=http://carbon-intensity-provider
       - LOG_LEVEL=debug
     expose:
       - 8080
+    ports:
+      - "8080:8080"
     networks:
       - private_network
     restart: unless-stopped

--- a/services/consumer-gateway/adapters/handler-http/handler_test.go
+++ b/services/consumer-gateway/adapters/handler-http/handler_test.go
@@ -20,7 +20,7 @@ func (f *FakeService) Login(ctx context.Context, req ports.ConsumerLoginRequest)
 }
 
 func (f *FakeService) CreateJob(ctx context.Context, req ports.CreateJobRequest) (ports.CreateJobResponse, error) {
-	if req.ImageID == "" || req.CreationZone == "" || req.Parameters == nil {
+	if req.CreationZone == "" || req.Parameters == nil {
 		return ports.CreateJobResponse{}, ports.ErrInvalidInput
 	}
 	return ports.CreateJobResponse{

--- a/services/consumer-gateway/core/consumer-gateway.go
+++ b/services/consumer-gateway/core/consumer-gateway.go
@@ -12,6 +12,8 @@ type ConsumerGatewayService struct {
 	login ports.LoginClient
 }
 
+var _ ports.Api = &ConsumerGatewayService{}
+
 func NewConsumerService(jobClient ports.JobClient, zoneClient ports.ZoneClient, loginClient ports.LoginClient) *ConsumerGatewayService {
 	return &ConsumerGatewayService{
 		job:   jobClient,
@@ -45,11 +47,11 @@ func (s *ConsumerGatewayService) GetZone(ctx context.Context, req ports.ZoneRequ
 }
 
 func (s *ConsumerGatewayService) Login(ctx context.Context, req ports.ConsumerLoginRequest) (ports.LoginResponse, error) {
-	resp, err := s.login.Login(ctx, req)
+	resp, err := s.login.Login(ctx, ports.LoginClientRequest{Secret: req.Username + "." + req.Password})
 	if err != nil {
 		return ports.LoginResponse{}, err
 	}
-	return resp, nil
+	return ports.LoginResponse{Secret: resp.Token}, nil
 }
 
 var _ ports.JobClient = (*ConsumerGatewayService)(nil)

--- a/services/consumer-gateway/core/consumer-gateway_test.go
+++ b/services/consumer-gateway/core/consumer-gateway_test.go
@@ -22,7 +22,7 @@ func (m *mockJobClient) CreateJob(ctx context.Context, req ports.CreateJobReques
 		return ports.CreateJobResponse{}, ports.ErrInvalidInput
 	}
 	return ports.CreateJobResponse{
-		ImageID: req.ImageID,
+		Image:   req.ImageID.Name,
 		JobName: req.JobName,
 	}, nil
 }
@@ -52,11 +52,11 @@ type mockLoginClient struct {
 	fail bool
 }
 
-func (m *mockLoginClient) Login(ctx context.Context, req ports.ConsumerLoginRequest) (ports.LoginResponse, error) {
+func (m *mockLoginClient) Login(ctx context.Context, req ports.LoginClientRequest) (ports.LoginClientResponse, error) {
 	if m.fail {
-		return ports.LoginResponse{}, ports.ErrUnauthorized
+		return ports.LoginClientResponse{}, ports.ErrUnauthorized
 	}
-	return ports.LoginResponse{Secret: "token-123"}, nil
+	return ports.LoginClientResponse{Token: "token-123"}, nil
 }
 
 func TestConsumerGatewayService_CreateJob(t *testing.T) {
@@ -64,7 +64,7 @@ func TestConsumerGatewayService_CreateJob(t *testing.T) {
 	service := core.NewConsumerService(jobMock, &mockZoneClient{}, &mockLoginClient{})
 
 	resp, err := service.CreateJob(context.Background(), ports.CreateJobRequest{
-		ImageID:      "img1",
+		ImageID:      ports.ContainerImage{Name: "img1", Version: "1.0"},
 		JobName:      "job-1",
 		CreationZone: "GER",
 	})
@@ -72,8 +72,8 @@ func TestConsumerGatewayService_CreateJob(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if resp.ImageID != "img1" {
-		t.Errorf("unexpected ImageID: %v", resp.ImageID)
+	if resp.Image != "img1" {
+		t.Errorf("unexpected ImageID: %v", resp.Image)
 	}
 }
 

--- a/services/consumer-gateway/main.go
+++ b/services/consumer-gateway/main.go
@@ -21,11 +21,11 @@ func main() {
 	}
 
 	// set port manually with "export PORT"
-	job := jobclient.NewJobClient(os.Getenv("JOB_SERVICE") + port)
-	user := jobclient.NewLoginClient(os.Getenv("USER_MANAGEMENT_SERVICE") + port)
-	zone := jobclient.NewZoneClient(os.Getenv("CARBON_INTENSITY_PROVIDER") + port)
+	job := jobclient.NewJobClient(os.Getenv("JOB_SERVICE") + ":" + port)
+	user := jobclient.NewLoginClient(os.Getenv("USER_MANAGEMENT_SERVICE") + ":" + port)
+	zone := jobclient.NewZoneClient(os.Getenv("CARBON_INTENSITY_PROVIDER") + ":" + port)
 	service := core.NewConsumerService(job, zone, user)
-	handler := handler_http.NewHandler(service, service, service)
+	handler := handler_http.NewHandler(service)
 
 	mux := http.NewServeMux()
 	mux.Handle("/", handler)

--- a/services/consumer-gateway/ports/api.go
+++ b/services/consumer-gateway/ports/api.go
@@ -1,6 +1,7 @@
 package ports
 
 import (
+	"context"
 	"errors"
 )
 
@@ -54,4 +55,11 @@ type ZoneRequest struct {
 
 type ZoneResponse struct {
 	Zone string `json:"zone"`
+}
+
+type Api interface {
+	CreateJob(ctx context.Context, req CreateJobRequest) (CreateJobResponse, error)
+	GetJobOutcome(ctx context.Context, jobID string) (JobOutcomeResponse, error)
+	GetZone(ctx context.Context, req ZoneRequest) (ZoneResponse, error)
+	Login(ctx context.Context, req ConsumerLoginRequest) (LoginResponse, error)
 }

--- a/services/consumer-gateway/ports/client.go
+++ b/services/consumer-gateway/ports/client.go
@@ -6,8 +6,16 @@ type ZoneClient interface {
 	GetZone(ctx context.Context, req ZoneRequest) (ZoneResponse, error)
 }
 
+type LoginClientRequest struct {
+	Secret string `json:"secret"`
+}
+
+type LoginClientResponse struct {
+	Token string `json:"token"`
+}
+
 type LoginClient interface {
-	Login(ctx context.Context, req ConsumerLoginRequest) (LoginResponse, error)
+	Login(ctx context.Context, req LoginClientRequest) (LoginClientResponse, error)
 }
 
 type JobClient interface {


### PR DESCRIPTION
I was just trying to obtain a token via the gateway's login endpoint. This didn't succeed. Turns out that the gateway client is currently not compatible with the user management API. I quickly fixed that. And while I was on it, I also fixed the tests and the docker-compose.yaml. When running "docker compose up --build" now, I can now successfully call
curl -X 'POST'   'http://localhost:8080/auth/login'   -H 'accept: application/json'   -H 'Content-Type: application/json'   -d '{ "username": "XXXXXXXXXXXXXXXXXXXXXXXXXXXX", "password": "XXXXXXXXXXXXXXXXXXXXXXXXXX" }'
please review.