### PR TITLE
Major changes to the makefiles and adding a pipeline file for azure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,76 @@
-# Makefile for building and testing all services in the project
-# This Makefile assumes that each service has its own Makefile in the services directory
+# Top-level Makefile for Multi-Service Go Project
+# 
+# This Makefile orchestrates building, testing, and deploying multiple Go services.
+# It assumes each service has its own Makefile located in services/<service>/.
+#
+# Key Features:
+# - Intelligent change detection: Only tests services with modified files
+# - Support for both PR and direct builds via BUILD_REASON environment variable
+# - Parallel service operations where possible
+# - Comprehensive error handling and logging
 
-INTEGRATION_SERVICES = carbon-intensity-provider cli consumer-gateway job job-scheduler user-management worker-deamon worker-gateway worker-registry
+# List of services that support full deployment (containerization)
+# Add new services here when they're ready for deployment
 DEPLOYMENT_SERVICES = carbon-intensity-provider consumer-gateway job job-scheduler user-management worker-gateway worker-registry
+
+# Base directory containing all microservices
 SERVICE_DIR = services
 
 .PHONY: integrationcheck deployment
 
+# Target: integrationcheck
+# Purpose: Run integration checks (clean, test, build) only for services with changed files
+# Usage: Called by Azure Pipelines for PR validation
+# Logic: 
+#   1. Detect changed files using git diff
+#   2. Extract service names from changed file paths
+#   3. Run integration checks only for affected services
+#   4. Skip execution if no service changes detected
+integrationcheck:
+	@echo "Detecting changed files since target branch..."; \
+	if [ "$$BUILD_REASON" = "PullRequest" ]; then \
+		echo "PR build detected, using Azure DevOps variables"; \
+		CHANGED_FILES=$$(git diff --name-only $$(git merge-base HEAD origin/main) HEAD); \
+	else \
+		echo "Direct build, comparing with main"; \
+		CHANGED_FILES=$$(git diff --name-only origin/main...HEAD 2>/dev/null || git diff --name-only HEAD~1 HEAD); \
+	fi; \
+	echo "Changed files: $$CHANGED_FILES"; \
+	CHANGED_SERVICES=""; \
+	for file in $$CHANGED_FILES; do \
+		if echo $$file | grep -q "^$(SERVICE_DIR)/"; then \
+			SERVICE=$$(echo $$file | cut -d'/' -f2); \
+			if [ ! -z "$$SERVICE" ] && [ -d "$(SERVICE_DIR)/$$SERVICE" ]; then \
+				if ! echo "$$CHANGED_SERVICES" | grep -q "$$SERVICE"; then \
+					CHANGED_SERVICES="$$CHANGED_SERVICES $$SERVICE"; \
+				fi; \
+			fi; \
+		fi; \
+	done; \
+	CHANGED_SERVICES=$$(echo $$CHANGED_SERVICES | xargs); \
+	if [ -z "$$CHANGED_SERVICES" ]; then \
+		echo "No service changes detected. Skipping integration check."; \
+	else \
+		echo "Running integration checks for changed services: $$CHANGED_SERVICES"; \
+		for service in $$CHANGED_SERVICES; do \
+			echo "Testing and building $$service..."; \
+			if [ -f "$(SERVICE_DIR)/$$service/Makefile" ]; then \
+				$(MAKE) -C $(SERVICE_DIR)/$$service integrationcheck || exit 1; \
+			else \
+				echo "Warning: No Makefile found for service $$service"; \
+			fi; \
+		done; \
+	fi
 
-# Calls the integration check for each service
-# Only services that have an integration check defined in their Makefile will be processed
-integrationcheck: 
-	@for service in $(INTEGRATION_SERVICES); do \
-		echo "Test and Building $$service ..."; \
-		$(MAKE) -C $(SERVICE_DIR)/$$service integrationcheck; \
-	done
-
-# Calls the deployment for each service
-# Only services that have a deployment defined in their Makefile will be processed
-# That excludes the cli and worker-deamon services
+# Target: deployment
+# Purpose: Run full deployment pipeline for all deployment-ready services
+# Usage: Called for production deployments or full system builds
+# Logic: Iterates through all services in DEPLOYMENT_SERVICES list
+# Note: This target processes ALL deployment services, regardless of changes
 deployment:
-	@for service in $(DEPLOYMENT_SERVICES); do \
-		echo "Containerizing $$service ..."; \
+	@echo "Starting deployment for all services..."; \
+	for service in $(DEPLOYMENT_SERVICES); do \
+		echo "Containerizing $$service..."; \
 		$(MAKE) -C $(SERVICE_DIR)/$$service deployment; \
-	done
-	
+	done; \
+	echo "Deployment pipeline completed for all services."

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,100 @@
+# Azure DevOps Pipeline for Multi-Service Go Project
+# This pipeline performs integration checks on changed services for pull requests
+# and can also run full deployments when merging to main branch.
+
+# Trigger configuration for automatic builds
+trigger:
+  branches:
+    include:
+      - main
+
+# Pull request trigger configuration
+pr:
+  branches:
+    include:
+      - main
+
+# Use Ubuntu Linux agent for all pipeline steps
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+  # Step 1: Install required dependencies for Go development and testing
+  - script: |
+      sudo apt-get update
+      sudo apt-get install -y make golang-go
+      go install github.com/jstemmer/go-junit-report@latest
+      go install github.com/t-yuki/gocover-cobertura@latest
+    displayName: 'Install make, Go, and test tools'
+
+  # Step 2: Checkout source code with full git history
+  # Full history is needed for accurate file change detection in PRs
+  - checkout: self
+    fetchDepth: 0  # Fetch full history
+    persistCredentials: true
+
+  # Step 3: Detect which files have changed to determine which services to test
+  # Different logic for PR builds vs direct pushes to main
+  - script: |
+      # Ensure we have the target branch for comparison
+      git fetch origin main:main || echo "Main branch already available"
+      # For PR builds, use Azure DevOps variables to get changed files
+      if [ "$BUILD_REASON" = "PullRequest" ]; then
+        echo "Pull Request build detected"
+        echo "Source branch: $SYSTEM_PULLREQUEST_SOURCEBRANCH"
+        echo "Target branch: $SYSTEM_PULLREQUEST_TARGETBRANCH"
+        # Use Azure DevOps built-in comparison
+        git diff --name-only origin/main...HEAD > changed_files.txt
+        echo "Changed files:"
+        cat changed_files.txt
+      else
+        echo "Non-PR build, comparing with main"
+        git diff --name-only HEAD~1 HEAD > changed_files.txt
+      fi
+    displayName: 'Detect changed files'
+
+  # Step 4: Run integration checks only for services that have changed
+  # This optimizes build time by only testing affected services
+  - script: |
+      export PATH=$PATH:$(go env GOPATH)/bin
+      make integrationcheck
+    displayName: 'Run integrationcheck (incl. tests and coverage)'
+
+  # Step 5: Debug step to verify test report generation
+  # Helps troubleshoot if test results aren't being published correctly
+  - script: |
+      ls -lah services/*/
+      find services/ -name "report.xml" -exec ls -la {} \; || echo "No report.xml files found"
+    displayName: 'Debug test report content'
+    
+  # Step 6: Publish test results to Azure DevOps
+  # Converts Go test output to JUnit format for Azure DevOps dashboard
+  - task: PublishTestResults@2
+    displayName: 'Publish Go Test Results'
+    condition: succeededOrFailed()        # Run even if tests failed
+    inputs:
+      testResultsFiles: '**/report.xml'   # Find all JUnit XML files
+      testRunTitle: 'Go Unit Tests'
+      searchFolder: '$(System.DefaultWorkingDirectory)'
+
+  # Step 7: Publish code coverage results to Azure DevOps
+  # Provides coverage metrics and visualization in Azure DevOps
+  - task: PublishCodeCoverageResults@2
+    displayName: 'Publish Code Coverage'
+    condition: succeededOrFailed()
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: 'services/*/coverage.xml'
+      reportDirectory: '.'
+
+  # Step 8: Deploy to production (only on main branch builds)
+  # This step runs the full deployment pipeline for all services
+  # Only executes when code is merged/pushed directly to main branch
+  - script: |
+      echo "Main branch build detected - starting deployment pipeline"
+      echo "Build reason: $BUILD_REASON"
+      echo "Source branch: $BUILD_SOURCEBRANCH"
+      export PATH=$PATH:$(go env GOPATH)/bin
+      make deployment
+    displayName: 'Deploy to Production'
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))

--- a/services/carbon-intensity-provider/Makefile
+++ b/services/carbon-intensity-provider/Makefile
@@ -1,27 +1,29 @@
 BINARY_NAME=carbon-intensity-provider-binary
 DOCKER_IMAGE=carbon-intensity-provider
 
-.PHONY: all build test containerize clean integrationcheck deployment
+.PHONY: all build test containerize clean integrationcheck deployment junit coverage
 
-integrationcheck:
-	@$(MAKE) build && \
-	$(MAKE) test ; \
-	$(MAKE) clean
-	
-deployment:
-	@$(MAKE) build && \
-	$(MAKE) test && \
-	$(MAKE) containerize ; \
-	$(MAKE) clean
+integrationcheck: clean test build
+
+deployment: clean test build containerize
+
+clean:
+	rm -f $(BINARY_NAME)
+	rm -f report.xml
+	rm -f coverage.out
+	rm -f coverage.xml
+
+test: junit coverage
+
+junit:
+	go test -v ./... | go-junit-report > report.xml
+
+coverage:
+	go test -coverprofile=coverage.out ./...
+	gocover-cobertura < coverage.out > coverage.xml
 
 build:
 	go build -o $(BINARY_NAME) .
 
-test:
-	go test ./...
-
 containerize:
 	docker build -t $(DOCKER_IMAGE) .
-
-clean:
-	rm -f $(BINARY_NAME)

--- a/services/cli/Makefile
+++ b/services/cli/Makefile
@@ -1,18 +1,27 @@
 BINARY_NAME=cli-binary
 
-.PHONY: all build test clean integrationcheck
+.PHONY: all build test containerize clean integrationcheck junit coverage
 
-integrationcheck:
-	@$(MAKE) build && \
-	$(MAKE) test ; \
-	$(MAKE) clean
+integrationcheck: clean test build
+
+clean:
+	rm -f $(BINARY_NAME)
+	rm -f report.xml
+	rm -f coverage.out
+	rm -f coverage.xml
+
+test: junit coverage
+
+junit:
+	go test -v ./... | go-junit-report > report.xml
+
+coverage:
+	go test -coverprofile=coverage.out ./...
+	gocover-cobertura < coverage.out > coverage.xml
 
 build:
 	go build -o $(BINARY_NAME) .
 
-test:
-	go test ./...
 
-clean:
-	rm -f $(BINARY_NAME)
+
 

--- a/services/consumer-gateway/Makefile
+++ b/services/consumer-gateway/Makefile
@@ -1,27 +1,29 @@
 BINARY_NAME=consumer-gateway-binary
 DOCKER_IMAGE=consumer-gateway
 
-.PHONY: all build test containerize clean integrationcheck deployment
+.PHONY: all build test containerize clean integrationcheck deployment junit coverage
 
-integrationcheck:
-	@$(MAKE) build && \
-	$(MAKE) test ; \
-	$(MAKE) clean
-	
-deployment:
-	@$(MAKE) build && \
-	$(MAKE) test && \
-	$(MAKE) containerize ; \
-	$(MAKE) clean
+integrationcheck: clean test build
+
+deployment: clean test build containerize
+
+clean:
+	rm -f $(BINARY_NAME)
+	rm -f report.xml
+	rm -f coverage.out
+	rm -f coverage.xml
+
+test: junit coverage
+
+junit:
+	go test -v ./... | go-junit-report > report.xml
+
+coverage:
+	go test -coverprofile=coverage.out ./...
+	gocover-cobertura < coverage.out > coverage.xml
 
 build:
 	go build -o $(BINARY_NAME) .
 
-test:
-	go test ./...
-
 containerize:
 	docker build -t $(DOCKER_IMAGE) .
-
-clean:
-	rm -f $(BINARY_NAME)

--- a/services/job-scheduler/Makefile
+++ b/services/job-scheduler/Makefile
@@ -1,30 +1,36 @@
 BINARY_NAME=job-scheduler-binary
 DOCKER_IMAGE=job-scheduler
 
-.PHONY: all build containerize test run docker-up docker-down clean integrationcheck deployment
+.PHONY: all build containerize test run docker-up docker-down clean integrationcheck deployment junit coverage
 
-integrationcheck:
-	@$(MAKE) build && \
-	$(MAKE) test ; \
-	$(MAKE) clean
+integrationcheck: clean test build
 
-deployment:
-	@$(MAKE) build && \
-	$(MAKE) test && \
-	$(MAKE) containerize ; \
-	$(MAKE) clean
+deployment: clean test build containerize
+
+clean:
+	rm -f $(BINARY_NAME)
+	rm -f report.xml
+	rm -f coverage.out
+	rm -f coverage.xml
+
+test: junit coverage
+
+junit:
+	go test -v ./... | go-junit-report > report.xml
+
+coverage:
+	go test -coverprofile=coverage.out ./...
+	gocover-cobertura < coverage.out > coverage.xml
 
 build:
 	go build -o $(BINARY_NAME) .
 
-test:
-	go test ./...
-
 containerize:
 	docker build -t $(DOCKER_IMAGE) .
 
+
 run:
-	WORKER_REGISTRY="http://localhost:8080" JOB_SERVICE="http://localhost:8080" CARBON_INTENSITY_PROVIDER="http://localhost:8080" USER_MANAGEMENT_URL=http://user-management:8080 AUTH_TOKEN="something to test, will probably need to be adjusted soon" OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318 JOB_SCHEDULER_SECRET="Some really secure secret"  go run main.go
+	WORKER_REGISTRY="http://localhost:8080" JOB_SERVICE="http://localhost:8080" CARBON_INTENSITY_PROVIDER="http://localhost:8080" go run main.go
 
 docker-up:
 	docker compose up --build -d
@@ -32,8 +38,7 @@ docker-up:
 docker-down:
 	docker compose down
 
-clean:
-	rm -f $(BINARY_NAME)
+
 
 
 

--- a/services/job/Makefile
+++ b/services/job/Makefile
@@ -1,28 +1,31 @@
 BINARY_NAME=job-binary
 DOCKER_IMAGE=job
 
-.PHONY: all build test containerize clean integrationcheck deployment
+.PHONY: all build test containerize clean integrationcheck deployment junit coverage
 
-integrationcheck:
-	@$(MAKE) build && \
-	$(MAKE) test ; \
-	$(MAKE) clean
-	
-deployment:
-	@$(MAKE) build && \
-	$(MAKE) test && \
-	$(MAKE) containerize ; \
-	$(MAKE) clean
+integrationcheck: clean test build
+
+deployment: clean test build containerize
+
+clean:
+	rm -f $(BINARY_NAME)
+	rm -f report.xml
+	rm -f coverage.out
+	rm -f coverage.xml
+
+test: junit coverage
+
+junit:
+	go test -v ./... | go-junit-report > report.xml
+
+coverage:
+	go test -coverprofile=coverage.out ./...
+	gocover-cobertura < coverage.out > coverage.xml
 
 build:
 	go build -o $(BINARY_NAME) .
 
-test:
-	go test ./...
-
 containerize:
 	docker build -t $(DOCKER_IMAGE) .
 
-clean:
-	rm -f $(BINARY_NAME)
 

--- a/services/user-management/Makefile
+++ b/services/user-management/Makefile
@@ -1,24 +1,29 @@
 BINARY_NAME=user-management-binary
 DOCKER_IMAGE=user-management
 
-.PHONY: all build test containerize run fmt docker-down clean integrationcheck deployment
+.PHONY: all build test containerize run fmt docker-down clean integrationcheck deployment junit coverage
 
-integrationcheck:
-	@$(MAKE) build && \
-	$(MAKE) test ; \
-	$(MAKE) clean
-	
-deployment:
-	@$(MAKE) build && \
-	$(MAKE) test && \
-	$(MAKE) containerize ; \
-	$(MAKE) clean
+integrationcheck: clean test build
+
+deployment: clean test build containerize
+
+clean:
+	rm -f $(BINARY_NAME)
+	rm -f report.xml
+	rm -f coverage.out
+	rm -f coverage.xml
+
+test: junit coverage
+
+junit:
+	go test -v ./... | go-junit-report > report.xml
+
+coverage:
+	go test -coverprofile=coverage.out ./...
+	gocover-cobertura < coverage.out > coverage.xml
 
 build:
 	go build -o $(BINARY_NAME) .
-
-test:
-	go test ./...
 
 containerize:
 	docker build -t $(DOCKER_IMAGE) .
@@ -31,6 +36,3 @@ fmt:
 
 docker-down:
 	docker compose down
-
-clean:
-	rm -f $(BINARY_NAME)

--- a/services/worker-deamon/Makefile
+++ b/services/worker-deamon/Makefile
@@ -1,19 +1,26 @@
 BINARY_NAME=worker-deamon-binary
-DOCKER_IMAGE=worker-deamon
 
-.PHONY: all build test integrationcheck clean
+.PHONY: all build test containerize clean integrationcheck junit coverage
 
-integrationcheck:
-	@$(MAKE) build && \
-	$(MAKE) test ; \
-	$(MAKE) clean
-
-build:
-	go build -o $(BINARY_NAME) ./cmd/worker-deamon
-
-test:
-	go test ./...
+integrationcheck: clean test build
 
 clean:
 	rm -f $(BINARY_NAME)
+	rm -f report.xml
+	rm -f coverage.out
+	rm -f coverage.xml
+
+test: junit coverage
+
+junit:
+	go test -v ./... | go-junit-report > report.xml
+
+coverage:
+	go test -coverprofile=coverage.out ./...
+	gocover-cobertura < coverage.out > coverage.xml
+
+build:
+	go build -o $(BINARY_NAME) .
+
+
 

--- a/services/worker-gateway/Makefile
+++ b/services/worker-gateway/Makefile
@@ -1,27 +1,29 @@
 BINARY_NAME=worker-gateway-binary
 DOCKER_IMAGE=worker-gateway
 
-.PHONY: all build test containerize clean integrationcheck deployment
+.PHONY: all build test containerize clean integrationcheck deployment junit coverage
 
-integrationcheck:
-	@$(MAKE) build && \
-	$(MAKE) test ; \
-	$(MAKE) clean
-	
-deployment:
-	@$(MAKE) build && \
-	$(MAKE) test && \
-	$(MAKE) containerize ; \
-	$(MAKE) clean
+integrationcheck: clean test build
+
+deployment: clean test build containerize
+
+clean:
+	rm -f $(BINARY_NAME)
+	rm -f report.xml
+	rm -f coverage.out
+	rm -f coverage.xml
+
+test: junit coverage
+
+junit:
+	go test -v ./... | go-junit-report > report.xml
+
+coverage:
+	go test -coverprofile=coverage.out ./...
+	gocover-cobertura < coverage.out > coverage.xml
 
 build:
 	go build -o $(BINARY_NAME) .
 
-test:
-	go test ./...
-
 containerize:
 	docker build -t $(DOCKER_IMAGE) .
-
-clean:
-	rm -f $(BINARY_NAME)

--- a/services/worker-registry/Makefile
+++ b/services/worker-registry/Makefile
@@ -1,24 +1,29 @@
 BINARY_NAME=worker-registry-binary
 DOCKER_IMAGE=worker-registry
 
-.PHONY: all build test containerize run fmt docker-up docker-down clean integrationcheck deployment
+.PHONY: all build test containerize run fmt docker-up docker-down clean integrationcheck deployment junit coverage
 
-integrationcheck:
-	@$(MAKE) build && \
-	$(MAKE) test ; \
-	$(MAKE) clean
+integrationcheck: clean test build
 
-deployment:
-	@$(MAKE) build && \
-	$(MAKE) test && \
-	$(MAKE) containerize ; \
-	$(MAKE) clean
+deployment: clean test build containerize
+
+clean:
+	rm -f $(BINARY_NAME)
+	rm -f report.xml
+	rm -f coverage.out
+	rm -f coverage.xml
+
+test: junit coverage
+
+junit:
+	go test -v ./... | go-junit-report > report.xml
+
+coverage:
+	go test -coverprofile=coverage.out ./...
+	gocover-cobertura < coverage.out > coverage.xml
 
 build:
 	go build -o $(BINARY_NAME) .
-
-test:
-	go test ./...
 
 containerize:
 	docker build -t $(DOCKER_IMAGE) .
@@ -31,6 +36,3 @@ docker-up:
 
 docker-down:
 	docker compose down
-
-clean:
-	rm -f $(BINARY_NAME)


### PR DESCRIPTION
1. Changes to all service makesfiles: creation of xml documentation using go-unit-report and gocover-cobertura, which are displayed by when running tests of the individual services in azure pipelines. The installation of the required libraries takes place in the pipeline itself. Change to the order of tasks for integrationcheck and deployment (clean at the beginning instead of the end)
2. Change in the root top layer makefile: The folders (services) in which actual changes were made in a feature branch are filtered using git diff. This speeds up the pipeline process, as an integration check is no longer carried out for all services.
3. Newly added: Pipeline file, it defines the triggers and individual steps that take place when either a pull request is performed or the main branch is merged. The changed service is also searched for here for the publication of the tests and code coverage using git diff.